### PR TITLE
add color Glauco ( Sea Green )

### DIFF
--- a/_colors.scss
+++ b/_colors.scss
@@ -21,6 +21,7 @@ $gray-blue: #707978;
 $gray-light: $grey-light;
 $gray: $grey;
 $gray-dark: $grey-dark;
+$glauco: #009966;
 
 $plat-light: $platinum-light;
 $plat: $platinum;


### PR DESCRIPTION
Add collor Glauco ( Sea Green) 
reference: #009966 ( middle the collors,  top color #0000FF; Button Collor: #00FF00 )
https://www.w3schools.com/colors/colors_mixer.asp